### PR TITLE
feat: respect smithy httpChecksum trait

### DIFF
--- a/.changeset/763369bf.md
+++ b/.changeset/763369bf.md
@@ -1,0 +1,5 @@
+---
+"aws-sdk-s3": minor
+---
+
+respect smithy checksum trait

--- a/services/s3/pyproject.toml
+++ b/services/s3/pyproject.toml
@@ -23,6 +23,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Faster CRC32C; the checksums are identical either way
+crc32c = ["google-crc32c"]
+# The XXHASH64, XXHASH3 and XXHASH128 checksum algorithms
+xxhash = ["xxhash"]
 # IAM Identity Center (SSO), assume-role and web-identity credentials providers
 sso = [
     "capo-sso>=0.2.0",

--- a/services/s3/src/capo_s3/_checksums.py
+++ b/services/s3/src/capo_s3/_checksums.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import zlib
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    ClassVar,
+    Literal,
+    Mapping,
+    Protocol,
+    Sequence,
+    Union,
+    cast,
+)
+
+from zapros import (
+    AsyncBaseHandler,
+    AsyncBaseMiddleware,
+    AsyncClosableStream,
+    BaseHandler,
+    BaseMiddleware,
+    ClosableStream,
+    Request,
+    Response,
+)
+
+from capo_s3.errors import ChecksumMismatch, ChecksumUnavailable
+
+if TYPE_CHECKING:
+    import google_crc32c
+else:
+    try:
+        import google_crc32c
+    except ImportError:
+        google_crc32c = None
+
+if TYPE_CHECKING:
+    import xxhash
+else:
+    try:
+        import xxhash
+    except ImportError:
+        xxhash = None
+
+ChecksumAlgorithm = Literal[
+    "CRC64NVME",
+    "CRC32C",
+    "CRC32",
+    "XXHASH3",
+    "XXHASH128",
+    "XXHASH64",
+    "MD5",
+    "SHA1",
+    "SHA256",
+    "SHA512",
+]
+
+Buffer = Union[bytes, bytearray, memoryview]
+
+
+class Hasher(Protocol):
+    """Anything with ``update()`` and ``digest()``: hashlib, xxhash, the CRCs below."""
+
+    def update(self, data: Buffer, /) -> None: ...
+
+    def digest(self) -> bytes: ...
+
+
+def _b64(hasher: Hasher) -> str:
+    return base64.b64encode(hasher.digest()).decode("ascii")
+
+
+_CRC32C_POLY = 0x82F63B78  # Castagnoli, reflected
+_CRC64NVME_POLY = 0x9A6C9329AC4BC9B5  # NVMe / Rocksoft, reflected
+
+
+def _crc_table(poly_reflected: int) -> list[int]:
+    table = []
+    for i in range(256):
+        crc = i
+        for _ in range(8):
+            crc = (crc >> 1) ^ (poly_reflected if crc & 1 else 0)
+        table.append(crc)
+    return table
+
+
+class _CrcHasher:
+    """Reflected CRC with all-ones init and final-xor.
+
+    The running value is the finalised CRC, which is also what zlib and
+    google-crc32c take and return, so an accelerated ``update`` drops in.
+    """
+
+    width: ClassVar[int]
+    _table: ClassVar[list[int]]
+
+    def __init__(self) -> None:
+        self._value = 0
+
+    def update(self, data: Buffer, /) -> None:
+        mask = (1 << self.width) - 1
+        crc = self._value ^ mask
+        for byte in bytes(data):
+            crc = self._table[(crc ^ byte) & 0xFF] ^ (crc >> 8)
+        self._value = crc ^ mask
+
+    def value(self) -> int:
+        return self._value
+
+    def digest(self) -> bytes:
+        return self._value.to_bytes(self.width // 8, "big")
+
+
+class Crc32Hasher(_CrcHasher):
+    """CRC-32/ISO-HDLC, 4 bytes."""
+
+    width = 32
+
+    def update(self, data: Buffer, /) -> None:
+        self._value = zlib.crc32(data, self._value)
+
+
+class Crc32cHasher(_CrcHasher):
+    """CRC-32C/Castagnoli, 4 bytes. Accelerated by google-crc32c when installed."""
+
+    width = 32
+    _table = _crc_table(_CRC32C_POLY)
+
+    def update(self, data: Buffer, /) -> None:
+        if google_crc32c is None:
+            super().update(data)
+        else:
+            self._value = google_crc32c.extend(self._value, data)
+
+
+class Crc64NvmeHasher(_CrcHasher):
+    """CRC-64/NVME, 8 bytes."""
+
+    width = 64
+    _table = _crc_table(_CRC64NVME_POLY)
+
+
+@dataclass(frozen=True)
+class Algorithm:
+    name: ChecksumAlgorithm
+    available: bool
+    factory: Callable[[], Hasher]
+
+    @property
+    def header(self) -> str:
+        return f"x-amz-checksum-{self.name.lower()}"
+
+
+def _xx_factory(attr: str, name: str) -> Callable[[], Hasher]:
+    def factory() -> Hasher:
+        if xxhash is None:
+            raise ChecksumUnavailable(f"{name} requires: pip install xxhash")
+        return cast(Hasher, getattr(xxhash, attr)())
+
+    return factory
+
+
+# Iteration order is the response-validation preference, cheapest first. Every
+# algorithm is listed whether or not its package is installed: recognising a
+# header is what lets us knowingly skip one we cannot compute.
+ALGORITHMS: dict[ChecksumAlgorithm, Algorithm] = {
+    spec.name: spec
+    for spec in (
+        Algorithm("CRC64NVME", True, Crc64NvmeHasher),
+        Algorithm("CRC32C", True, Crc32cHasher),
+        Algorithm("CRC32", True, Crc32Hasher),
+        Algorithm("XXHASH3", xxhash is not None, _xx_factory("xxh3_64", "XXHASH3")),
+        Algorithm(
+            "XXHASH128", xxhash is not None, _xx_factory("xxh3_128", "XXHASH128")
+        ),
+        Algorithm("XXHASH64", xxhash is not None, _xx_factory("xxh64", "XXHASH64")),
+        Algorithm("MD5", True, hashlib.md5),
+        Algorithm("SHA1", True, hashlib.sha1),
+        Algorithm("SHA256", True, hashlib.sha256),
+        Algorithm("SHA512", True, hashlib.sha512),
+    )
+}
+
+LEGACY_MD5_HEADER = "Content-MD5"
+_FLEXIBLE_HEADERS: frozenset[str] = frozenset(
+    spec.header for spec in ALGORITHMS.values()
+)
+DEFAULT_REQUEST_ALGORITHM: ChecksumAlgorithm = "CRC32"
+
+
+def compute(algorithm: ChecksumAlgorithm, data: Buffer) -> str:
+    """The base64 checksum of an in-memory body. The name is case-insensitive."""
+    spec = ALGORITHMS.get(cast(ChecksumAlgorithm, algorithm.upper()))
+    if spec is None:
+        raise ValueError(f"unsupported checksum algorithm: {algorithm}")
+    hasher = spec.factory()
+    hasher.update(data)
+    return _b64(hasher)
+
+
+def set_request_checksum(
+    headers: dict[str, str], body: object, algorithm: ChecksumAlgorithm | None
+) -> None:
+    """Set ``x-amz-checksum-<algorithm>`` for a buffered request body.
+
+    ``algorithm`` is what the caller passed for the operation's
+    requestAlgorithmMember; None means nobody asked and the default applies.
+    Passing it also sends ``x-amz-sdk-checksum-algorithm``, which the service
+    rejects unless a matching checksum ships with it, so a requested algorithm
+    is either computed or refused -- never quietly dropped.
+    """
+    present = {key.lower() for key in headers}
+    if present & _FLEXIBLE_HEADERS:  # a hand-supplied checksum wins
+        return
+    if not isinstance(body, (bytes, bytearray, memoryview)):
+        if algorithm is not None:
+            raise ValueError(
+                f"a {algorithm} checksum was requested for a streaming body, which cannot be "
+                f"checksummed without buffering all of it. Send the body as bytes, or set the "
+                f"x-amz-checksum-* member on the input yourself."
+            )
+        return
+    # Content-MD5 covers integrity, but does not stand in for a requested algorithm.
+    if algorithm is None and LEGACY_MD5_HEADER.lower() in present:
+        return
+    name = cast(ChecksumAlgorithm, (algorithm or DEFAULT_REQUEST_ALGORITHM).upper())
+    headers[ALGORITHMS[name].header] = compute(name, cast(Buffer, body))
+
+
+def is_composite(value: str) -> bool:
+    """Whether a value is a multipart checksum, which S3 writes ``<base64>-<parts>``.
+
+    Reproducing one needs the part boundaries, which the response does not carry.
+    """
+    _, dash, count = value.rpartition("-")
+    return bool(dash and count.isdigit())
+
+
+def _expected_checksum(
+    response_algorithms: Sequence[ChecksumAlgorithm],
+    headers: Mapping[str, str],
+) -> tuple[ChecksumAlgorithm, str] | None:
+    """The algorithm to validate with and the value the service sent, or None.
+
+    None means nothing here is verifiable -- unrecognised, not installed, or
+    composite -- which is skipped rather than failed.
+    """
+    allowed = {name.upper() for name in response_algorithms}
+    present = {key.lower(): value for key, value in headers.items()}
+    for name, spec in ALGORITHMS.items():
+        if name not in allowed or not spec.available:
+            continue
+        value = present.get(spec.header)
+        if value is not None and not is_composite(value):
+            return name, value
+    return None
+
+
+class ChecksumStream(AsyncClosableStream, ClosableStream):
+    """The response body, hashed on its way to the caller.
+
+    Reads ``iter_raw`` because the service checksums the bytes it sent, not the
+    content-decoded ones. Whichever of ``__next__`` / ``__anext__`` the response
+    is driven by picks the matching underlying stream.
+    """
+
+    def __init__(
+        self, response: Response, algorithm: ChecksumAlgorithm, expected: str
+    ) -> None:
+        self.response = response
+        self.algorithm = algorithm
+        self.expected = expected
+        self.hasher = ALGORITHMS[algorithm].factory()
+        self.sync_raw_stream = response.iter_raw()
+        self.async_raw_stream = response.async_iter_raw()
+
+    def verify(self) -> None:
+        actual = _b64(self.hasher)
+        if actual != self.expected:
+            raise ChecksumMismatch(self.algorithm, self.expected, actual)
+
+    def __next__(self) -> bytes:
+        try:
+            chunk = next(self.sync_raw_stream)
+        except StopIteration:
+            self.verify()
+            raise
+        self.hasher.update(chunk)
+        return chunk
+
+    async def __anext__(self) -> bytes:
+        try:
+            chunk = await self.async_raw_stream.__anext__()
+        except StopAsyncIteration:
+            self.verify()
+            raise
+        self.hasher.update(chunk)
+        return chunk
+
+    def close(self) -> None:
+        self.response.close()
+
+    async def aclose(self) -> None:
+        await self.response.aclose()
+
+
+class ChecksumMiddleware(BaseMiddleware, AsyncBaseMiddleware):
+    """Validate response bodies against the checksum header the service sent.
+
+    The operation's responseAlgorithms arrive in ``context["checksum_algorithms"]``.
+    """
+
+    def __init__(self, next_handler: BaseHandler | AsyncBaseHandler) -> None:
+        self.next = cast(BaseHandler, next_handler)
+        self.async_next = cast(AsyncBaseHandler, next_handler)
+
+    def handle(self, request: Request) -> Response:
+        return _validating(request, self.next.handle(request))
+
+    async def ahandle(self, request: Request) -> Response:
+        return _validating(request, await self.async_next.ahandle(request))
+
+
+def _validating(request: Request, response: Response) -> Response:
+    """``response`` with a checksum-verifying body, or unchanged if none applies."""
+    # A ranged GET is answered with the whole object's checksum over a slice of
+    # its body. partNumber is unaffected: that returns the part's own checksum.
+    if "range" in request.headers:
+        return response
+    algorithms = cast(
+        "Sequence[ChecksumAlgorithm]", request.context.get("checksum_algorithms", ())
+    )
+    found = _expected_checksum(algorithms, response.headers)
+    if found is None:
+        return response
+    algorithm, expected = found
+    return Response(
+        response.status,
+        response.headers,
+        content=ChecksumStream(response, algorithm, expected),
+        context=response.context,
+        request=response.request,
+    )

--- a/services/s3/src/capo_s3/_checksums.py
+++ b/services/s3/src/capo_s3/_checksums.py
@@ -185,10 +185,30 @@ ALGORITHMS: dict[ChecksumAlgorithm, Algorithm] = {
 }
 
 LEGACY_MD5_HEADER = "Content-MD5"
+SDK_ALGORITHM_HEADER = "x-amz-sdk-checksum-algorithm"
 _FLEXIBLE_HEADERS: frozenset[str] = frozenset(
     spec.header for spec in ALGORITHMS.values()
 )
+_STRIPPED_HEADERS: frozenset[str] = _FLEXIBLE_HEADERS | {
+    SDK_ALGORITHM_HEADER,
+    LEGACY_MD5_HEADER.lower(),
+}
 DEFAULT_REQUEST_ALGORITHM: ChecksumAlgorithm = "CRC32"
+
+
+def strip_checksum_headers(request: Request) -> Request:
+    """Drop every header that binds a request to a body, in place.
+
+    For presigning: the URL is handed to someone else, who supplies the body,
+    and presigning signs whatever headers it finds -- so any checksum left here
+    is one the holder of the URL must reproduce exactly. That covers
+    Content-MD5 as much as the x-amz-checksum-* family, and
+    x-amz-sdk-checksum-algorithm goes too, since the service rejects that
+    header without a matching value.
+    """
+    for name in [key for key in request.headers if key.lower() in _STRIPPED_HEADERS]:
+        del request.headers[name]
+    return request
 
 
 def compute(algorithm: ChecksumAlgorithm, data: Buffer) -> str:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/create_bucket_metadata_configuration.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/create_bucket_metadata_configuration.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.create_bucket_metadata_configuration_request
@@ -96,6 +97,9 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/create_bucket_metadata_table_configuration.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/create_bucket_metadata_table_configuration.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.create_bucket_metadata_table_configuration_request
@@ -98,6 +99,9 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/delete_objects.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/delete_objects.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.delete
@@ -136,6 +137,9 @@ def build_request(
     capo_s3.types.delete.serialize_xml(input_["delete"], payload_root, "Delete")
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/get_object.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/get_object.py
@@ -339,6 +339,20 @@ def get_signer(
     raise RuntimeError("Auth was not resolved")
 
 
+RESPONSE_CHECKSUM_ALGORITHMS = (
+    "CRC64NVME",
+    "CRC32",
+    "CRC32C",
+    "SHA256",
+    "SHA1",
+    "SHA512",
+    "MD5",
+    "XXHASH64",
+    "XXHASH3",
+    "XXHASH128",
+)
+
+
 def build_request(
     options: OperationOptions | AsyncOperationOptions,
     input_: capo_s3.types.get_object_request.GetObjectRequest,
@@ -438,11 +452,14 @@ def build_request(
         )
     body: bytes | None = b""
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
+    context: zapros.RequestContext = {"signer": signer}
+    if input_.get("checksum_mode") == "ENABLED":
+        context["checksum_algorithms"] = RESPONSE_CHECKSUM_ALGORITHMS
     normalized_url = zapros.URL(url)
     for k, v in params:
         normalized_url.search_params.append(k, v)
     return zapros.Request(
-        normalized_url, "GET", headers=headers, body=body, context={"signer": signer}
+        normalized_url, "GET", headers=headers, body=body, context=context
     )
 
 

--- a/services/s3/src/capo_s3/_operations/amazon_s3/get_object_annotation.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/get_object_annotation.py
@@ -184,6 +184,20 @@ def get_signer(
     raise RuntimeError("Auth was not resolved")
 
 
+RESPONSE_CHECKSUM_ALGORITHMS = (
+    "CRC64NVME",
+    "CRC32",
+    "CRC32C",
+    "SHA256",
+    "SHA1",
+    "SHA512",
+    "MD5",
+    "XXHASH64",
+    "XXHASH3",
+    "XXHASH128",
+)
+
+
 def build_request(
     options: OperationOptions | AsyncOperationOptions,
     input_: capo_s3.types.get_object_annotation_request.GetObjectAnnotationRequest,
@@ -236,11 +250,14 @@ def build_request(
         )
     body: bytes | None = b""
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
+    context: zapros.RequestContext = {"signer": signer}
+    if input_.get("checksum_mode") == "ENABLED":
+        context["checksum_algorithms"] = RESPONSE_CHECKSUM_ALGORITHMS
     normalized_url = zapros.URL(url)
     for k, v in params:
         normalized_url.search_params.append(k, v)
     return zapros.Request(
-        normalized_url, "GET", headers=headers, body=body, context={"signer": signer}
+        normalized_url, "GET", headers=headers, body=body, context=context
     )
 
 

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_abac.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_abac.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.abac_status
 import capo_s3.types.checksum_algorithm
@@ -96,6 +97,10 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    if "checksum_algorithm" in input_:
+        capo_s3._checksums.set_request_checksum(
+            headers, body, input_.get("checksum_algorithm")
+        )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_accelerate_configuration.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_accelerate_configuration.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.accelerate_configuration
 import capo_s3.types.checksum_algorithm
@@ -94,6 +95,10 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    if "checksum_algorithm" in input_:
+        capo_s3._checksums.set_request_checksum(
+            headers, body, input_.get("checksum_algorithm")
+        )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_acl.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_acl.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.access_control_policy
 import capo_s3.types.bucket_canned_acl
@@ -115,6 +116,9 @@ def build_request(
         headers["content-type"] = "application/xml"
     else:
         body = b""
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_cors.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_cors.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.cors_configuration
@@ -96,6 +97,9 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_encryption.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_encryption.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.put_bucket_encryption_request
@@ -98,6 +99,9 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_lifecycle_configuration.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_lifecycle_configuration.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.bucket_lifecycle_configuration
 import capo_s3.types.checksum_algorithm
@@ -132,6 +133,9 @@ def build_request(
         headers["content-type"] = "application/xml"
     else:
         body = b""
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_logging.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_logging.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.bucket_logging_status
 import capo_s3.types.checksum_algorithm
@@ -96,6 +97,9 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_ownership_controls.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_ownership_controls.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.ownership_controls
@@ -96,6 +97,9 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_policy.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_policy.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.put_bucket_policy_request
@@ -95,6 +96,9 @@ def build_request(
         headers["x-amz-expected-bucket-owner"] = input_["expected_bucket_owner"]
     body: bytes | None = input_["policy"].encode()
     headers["content-type"] = "text/plain"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_replication.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_replication.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.put_bucket_replication_request
@@ -98,6 +99,9 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_request_payment.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_request_payment.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.put_bucket_request_payment_request
@@ -98,6 +99,9 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_tagging.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_tagging.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.put_bucket_tagging_request
@@ -94,6 +95,9 @@ def build_request(
     capo_s3.types.tagging.serialize_xml(input_["tagging"], payload_root, "Tagging")
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_versioning.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_versioning.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.put_bucket_versioning_request
@@ -98,6 +99,9 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_website.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_bucket_website.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.put_bucket_website_request
@@ -96,6 +97,9 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_object.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_object.py
@@ -10,6 +10,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.errors.encryption_type_mismatch
 import capo_s3.errors.invalid_request
@@ -387,6 +388,10 @@ def build_request(
         header.lower() for header in headers
     ]:
         raise ValueError("Content-Length is required for streaming input")
+    if "checksum_algorithm" in input_:
+        capo_s3._checksums.set_request_checksum(
+            headers, body, input_.get("checksum_algorithm")
+        )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_object_acl.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_object_acl.py
@@ -10,6 +10,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.errors.no_such_key
 import capo_s3.types.access_control_policy
@@ -158,6 +159,9 @@ def build_request(
         headers["content-type"] = "application/xml"
     else:
         body = b""
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_object_annotation.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_object_annotation.py
@@ -10,6 +10,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.errors.annotation_limit_exceeded
 import capo_s3.errors.annotation_name_too_long
@@ -270,6 +271,10 @@ def build_request(
         header.lower() for header in headers
     ]:
         raise ValueError("Content-Length is required for streaming input")
+    if "checksum_algorithm" in input_:
+        capo_s3._checksums.set_request_checksum(
+            headers, body, input_.get("checksum_algorithm")
+        )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_object_legal_hold.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_object_legal_hold.py
@@ -10,6 +10,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.object_lock_legal_hold
@@ -133,6 +134,9 @@ def build_request(
         headers["content-type"] = "application/xml"
     else:
         body = b""
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_object_lock_configuration.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_object_lock_configuration.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.object_lock_configuration
@@ -135,6 +136,9 @@ def build_request(
         headers["content-type"] = "application/xml"
     else:
         body = b""
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_object_retention.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_object_retention.py
@@ -10,6 +10,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.object_lock_retention
@@ -137,6 +138,9 @@ def build_request(
         headers["content-type"] = "application/xml"
     else:
         body = b""
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_object_tagging.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_object_tagging.py
@@ -10,6 +10,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.put_object_tagging_output
@@ -123,6 +124,9 @@ def build_request(
     capo_s3.types.tagging.serialize_xml(input_["tagging"], payload_root, "Tagging")
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/put_public_access_block.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/put_public_access_block.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.public_access_block_configuration
@@ -98,6 +99,9 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/restore_object.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/restore_object.py
@@ -10,6 +10,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.errors.object_already_in_active_tier_error
 import capo_s3.types.checksum_algorithm
@@ -146,6 +147,10 @@ def build_request(
         headers["content-type"] = "application/xml"
     else:
         body = b""
+    if "checksum_algorithm" in input_:
+        capo_s3._checksums.set_request_checksum(
+            headers, body, input_.get("checksum_algorithm")
+        )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/update_bucket_metadata_annotation_table_configuration.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/update_bucket_metadata_annotation_table_configuration.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.annotation_table_configuration_updates
 import capo_s3.types.checksum_algorithm
@@ -98,6 +99,9 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/update_bucket_metadata_inventory_table_configuration.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/update_bucket_metadata_inventory_table_configuration.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.inventory_table_configuration_updates
@@ -98,6 +99,9 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/update_bucket_metadata_journal_table_configuration.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/update_bucket_metadata_journal_table_configuration.py
@@ -9,6 +9,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.journal_table_configuration_updates
@@ -96,6 +97,9 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/update_object_encryption.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/update_object_encryption.py
@@ -10,6 +10,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.errors.access_denied
 import capo_s3.errors.invalid_request
@@ -147,6 +148,9 @@ def build_request(
     )
     body: bytes | None = tostring(payload_root[0])
     headers["content-type"] = "application/xml"
+    capo_s3._checksums.set_request_checksum(
+        headers, body, input_.get("checksum_algorithm")
+    )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_operations/amazon_s3/upload_part.py
+++ b/services/s3/src/capo_s3/_operations/amazon_s3/upload_part.py
@@ -10,6 +10,7 @@ from typing_extensions import Never
 
 import capo_s3._auth._signers
 import capo_s3._auth._sigv4
+import capo_s3._checksums
 import capo_s3._protocol.eventstream
 import capo_s3.types.checksum_algorithm
 import capo_s3.types.request_charged
@@ -258,6 +259,10 @@ def build_request(
         header.lower() for header in headers
     ]:
         raise ValueError("Content-Length is required for streaming input")
+    if "checksum_algorithm" in input_:
+        capo_s3._checksums.set_request_checksum(
+            headers, body, input_.get("checksum_algorithm")
+        )
     signer = get_signer(options, auth_schemes=endpoint.properties.get("authSchemes"))
     normalized_url = zapros.URL(url)
     for k, v in params:

--- a/services/s3/src/capo_s3/_services/async_s3.py
+++ b/services/s3/src/capo_s3/_services/async_s3.py
@@ -23,7 +23,7 @@ from capo_s3._auth._providers import (
 from capo_s3._auth._signers import SigV4Signer
 from capo_s3._auth._sigv4 import presign_sigv4
 from capo_s3._auth._zapros_handler import AuthMiddleware
-from capo_s3._checksums import ChecksumMiddleware
+from capo_s3._checksums import ChecksumMiddleware, strip_checksum_headers
 from capo_s3._iter import ensure_async_iterator
 from capo_s3._pagination import resolve_path as _resolve_path
 from capo_s3._services._aws_config import aaws_config
@@ -2394,6 +2394,7 @@ class AsyncS3Client:
         request = capo_s3._operations.amazon_s3.delete_object.build_request(
             options_, input_
         )
+        request = strip_checksum_headers(request)
         signer = (request.context or {}).get("signer")
         if not isinstance(signer, SigV4Signer):
             raise RuntimeError("presign requires SigV4 credentials")
@@ -4068,6 +4069,7 @@ class AsyncS3Client:
         request = capo_s3._operations.amazon_s3.get_object.build_request(
             options_, input_
         )
+        request = strip_checksum_headers(request)
         signer = (request.context or {}).get("signer")
         if not isinstance(signer, SigV4Signer):
             raise RuntimeError("presign requires SigV4 credentials")
@@ -5034,6 +5036,7 @@ class AsyncS3Client:
         request = capo_s3._operations.amazon_s3.head_object.build_request(
             options_, input_
         )
+        request = strip_checksum_headers(request)
         signer = (request.context or {}).get("signer")
         if not isinstance(signer, SigV4Signer):
             raise RuntimeError("presign requires SigV4 credentials")
@@ -7932,6 +7935,7 @@ class AsyncS3Client:
         request = capo_s3._operations.amazon_s3.put_object.build_request(
             options_, input_
         )
+        request = strip_checksum_headers(request)
         signer = (request.context or {}).get("signer")
         if not isinstance(signer, SigV4Signer):
             raise RuntimeError("presign requires SigV4 credentials")
@@ -9322,6 +9326,7 @@ class AsyncS3Client:
         request = capo_s3._operations.amazon_s3.upload_part.build_request(
             options_, input_
         )
+        request = strip_checksum_headers(request)
         signer = (request.context or {}).get("signer")
         if not isinstance(signer, SigV4Signer):
             raise RuntimeError("presign requires SigV4 credentials")

--- a/services/s3/src/capo_s3/_services/async_s3.py
+++ b/services/s3/src/capo_s3/_services/async_s3.py
@@ -23,6 +23,7 @@ from capo_s3._auth._providers import (
 from capo_s3._auth._signers import SigV4Signer
 from capo_s3._auth._sigv4 import presign_sigv4
 from capo_s3._auth._zapros_handler import AuthMiddleware
+from capo_s3._checksums import ChecksumMiddleware
 from capo_s3._iter import ensure_async_iterator
 from capo_s3._pagination import resolve_path as _resolve_path
 from capo_s3._services._aws_config import aaws_config
@@ -457,8 +458,10 @@ class AsyncS3Client:
         accelerate: bool | None = None,
         disable_s3_express_session_auth: bool | None = None,
     ):
-        self._client = AsyncClient(http_handler).wrap_with_middleware(
-            lambda next: AuthMiddleware(next)
+        self._client = (
+            AsyncClient(http_handler)
+            .wrap_with_middleware(lambda next: AuthMiddleware(next))
+            .wrap_with_middleware(lambda next: ChecksumMiddleware(next))
         )
         if credentials is not None and credentials_provider is not None:
             warnings.warn(

--- a/services/s3/src/capo_s3/_services/s3.py
+++ b/services/s3/src/capo_s3/_services/s3.py
@@ -22,7 +22,7 @@ from capo_s3._auth._providers import (
 from capo_s3._auth._signers import SigV4Signer
 from capo_s3._auth._sigv4 import presign_sigv4
 from capo_s3._auth._zapros_handler import AuthMiddleware
-from capo_s3._checksums import ChecksumMiddleware
+from capo_s3._checksums import ChecksumMiddleware, strip_checksum_headers
 from capo_s3._iter import ensure_sync_iterator
 from capo_s3._pagination import resolve_path as _resolve_path
 from capo_s3._services._aws_config import aws_config
@@ -2363,6 +2363,7 @@ class S3Client:
         request = capo_s3._operations.amazon_s3.delete_object.build_request(
             options_, input_
         )
+        request = strip_checksum_headers(request)
         signer = (request.context or {}).get("signer")
         if not isinstance(signer, SigV4Signer):
             raise RuntimeError("presign requires SigV4 credentials")
@@ -4007,6 +4008,7 @@ class S3Client:
         request = capo_s3._operations.amazon_s3.get_object.build_request(
             options_, input_
         )
+        request = strip_checksum_headers(request)
         signer = (request.context or {}).get("signer")
         if not isinstance(signer, SigV4Signer):
             raise RuntimeError("presign requires SigV4 credentials")
@@ -4956,6 +4958,7 @@ class S3Client:
         request = capo_s3._operations.amazon_s3.head_object.build_request(
             options_, input_
         )
+        request = strip_checksum_headers(request)
         signer = (request.context or {}).get("signer")
         if not isinstance(signer, SigV4Signer):
             raise RuntimeError("presign requires SigV4 credentials")
@@ -7814,6 +7817,7 @@ class S3Client:
         request = capo_s3._operations.amazon_s3.put_object.build_request(
             options_, input_
         )
+        request = strip_checksum_headers(request)
         signer = (request.context or {}).get("signer")
         if not isinstance(signer, SigV4Signer):
             raise RuntimeError("presign requires SigV4 credentials")
@@ -9185,6 +9189,7 @@ class S3Client:
         request = capo_s3._operations.amazon_s3.upload_part.build_request(
             options_, input_
         )
+        request = strip_checksum_headers(request)
         signer = (request.context or {}).get("signer")
         if not isinstance(signer, SigV4Signer):
             raise RuntimeError("presign requires SigV4 credentials")

--- a/services/s3/src/capo_s3/_services/s3.py
+++ b/services/s3/src/capo_s3/_services/s3.py
@@ -22,6 +22,7 @@ from capo_s3._auth._providers import (
 from capo_s3._auth._signers import SigV4Signer
 from capo_s3._auth._sigv4 import presign_sigv4
 from capo_s3._auth._zapros_handler import AuthMiddleware
+from capo_s3._checksums import ChecksumMiddleware
 from capo_s3._iter import ensure_sync_iterator
 from capo_s3._pagination import resolve_path as _resolve_path
 from capo_s3._services._aws_config import aws_config
@@ -456,8 +457,10 @@ class S3Client:
         accelerate: bool | None = None,
         disable_s3_express_session_auth: bool | None = None,
     ):
-        self._client = Client(http_handler).wrap_with_middleware(
-            lambda next: AuthMiddleware(next)
+        self._client = (
+            Client(http_handler)
+            .wrap_with_middleware(lambda next: AuthMiddleware(next))
+            .wrap_with_middleware(lambda next: ChecksumMiddleware(next))
         )
         if credentials is not None and credentials_provider is not None:
             warnings.warn(

--- a/services/s3/src/capo_s3/errors/__init__.py
+++ b/services/s3/src/capo_s3/errors/__init__.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
 from ._base import (
+    ChecksumMismatch as ChecksumMismatch,
+)
+from ._base import (
+    ChecksumUnavailable as ChecksumUnavailable,
+)
+from ._base import (
     DeserializationError as DeserializationError,
 )
 from ._base import (

--- a/services/s3/src/capo_s3/errors/_base.py
+++ b/services/s3/src/capo_s3/errors/_base.py
@@ -92,3 +92,19 @@ class WaiterTimeoutError(S3Error):
         )
         self.waiter_name = waiter_name
         self.max_wait_time = max_wait_time
+
+
+class ChecksumUnavailable(S3Error):
+    """An algorithm whose backing package is not installed."""
+
+
+class ChecksumMismatch(S3Error):
+    """A response body did not match the checksum the service sent."""
+
+    def __init__(self, algorithm: str, expected: str, actual: str) -> None:
+        super().__init__(
+            f"{algorithm} checksum mismatch: expected {expected}, got {actual}"
+        )
+        self.algorithm = algorithm
+        self.expected = expected
+        self.actual = actual


### PR DESCRIPTION
Closes #34

This PR adds support for Smithy's [httpChecksum](https://smithy.io/2.0/aws/aws-core.html#aws-protocols-httpchecksum-trait) trait.

For operations with `requestChecksumRequired` set to `true`, the SDK now computes the checksum (see `_checksums.py`) and sets the appropriate header.

When the input parameter named by `requestValidationModeMember` is enabled, the SDK also validates the response checksum. This works for streaming responses too.

Checksums are not yet computed for streaming requests.

Example: 

```python
delete = {"objects": [{"key": "obj.txt"}], "quiet": True}

# No algorithm requested -> the SDK uses the default (CRC32).
client.delete_objects(bucket, delete)
# x-amz-checksum-crc32: Z6ZkKg==

# An explicit algorithm is sent alongside the checksum it declares.
client.delete_objects(bucket, delete, checksum_algorithm="SHA256")
# x-amz-sdk-checksum-algorithm: SHA256
# x-amz-checksum-sha256: ToodltPB9dtXGGIEot1vO4NlfSscU1Jt0AA/Touj7IE=
```

A checksum you set yourself always wins, and the SDK never sends two.
